### PR TITLE
Revert socket blocking mode changes

### DIFF
--- a/src/nopoll_conn.c
+++ b/src/nopoll_conn.c
@@ -328,11 +328,12 @@ NOPOLL_SOCKET __nopoll_conn_sock_connect_opts_internal (noPollCtx       * ctx,
 	} /* end if */
 
 	/* set non blocking status */
-	nopoll_log (ctx, NOPOLL_LEVEL_DEBUG,"Create socket with blocking-mode");
-	nopoll_conn_set_sock_block (session, nopoll_true);
+	nopoll_log (ctx, NOPOLL_LEVEL_INFO,"Create socket with non blocking-mode");
+	nopoll_conn_set_sock_block (session, nopoll_false);
 	
 	/* do a tcp connect */
         if (connect (session, res->ai_addr, res->ai_addrlen) < 0) {
+		if(errno != NOPOLL_EINPROGRESS && errno != NOPOLL_EWOULDBLOCK && errno != NOPOLL_ENOTCONN) {
 		        shutdown (session, SHUT_RDWR);
                         nopoll_close_socket (session);
 
@@ -343,6 +344,7 @@ NOPOLL_SOCKET __nopoll_conn_sock_connect_opts_internal (noPollCtx       * ctx,
 			freeaddrinfo (res);
 			
 			return -1;
+		}
 	}
 	else
 	{


### PR DESCRIPTION
With the --force-ipv4 and --force-ipv6 flag, parodus should connect to server in IPv4/IPv6 mode even in non-blocking mode.  