### PR TITLE
Send SNI in the presence of an TLS server

### DIFF
--- a/src/nopoll_conn.c
+++ b/src/nopoll_conn.c
@@ -994,6 +994,9 @@ noPollConn * __nopoll_conn_new_common (noPollCtx       * ctx,
 			return conn;
 		} /* end if */
 		
+		/*Set SNI (Server Name Indication) Hostname */
+		SSL_set_tlsext_host_name(conn->ssl, conn->host_name);
+
 		/* set socket */
 		SSL_set_fd (conn->ssl, conn->session);
 


### PR DESCRIPTION
If a server we try to contact is being hosted on a machine which responds
to several host names, the server doesn't request the certificate, thus
the client will not send the certificate.

Signed-off-by: Nuno Martins <nuno.mmartins@parceiros.nos.pt>