### PR TITLE
fix log of connect error

### DIFF
--- a/src/nopoll_conn.c
+++ b/src/nopoll_conn.c
@@ -334,11 +334,11 @@ NOPOLL_SOCKET __nopoll_conn_sock_connect_opts_internal (noPollCtx       * ctx,
 	/* do a tcp connect */
         if (connect (session, res->ai_addr, res->ai_addrlen) < 0) {
 		if(errno != NOPOLL_EINPROGRESS && errno != NOPOLL_EWOULDBLOCK && errno != NOPOLL_ENOTCONN) {
-		        shutdown (session, SHUT_RDWR);
-                        nopoll_close_socket (session);
-
 			nopoll_log (ctx, NOPOLL_LEVEL_CRITICAL, "unable to connect to remote host %s:%s errno=%d",
 				    host, port, errno);
+
+		        shutdown (session, SHUT_RDWR);
+                        nopoll_close_socket (session);
 
 			/* relase address info */
 			freeaddrinfo (res);


### PR DESCRIPTION
In nopoll_conn.c, correct position of log statement after connect error, so that errno is reported correctly. 