### PR TITLE
Bad msg

### DIFF
--- a/src/nopoll_ctx.c
+++ b/src/nopoll_ctx.c
@@ -335,6 +335,7 @@ void           nopoll_ctx_unregister_conn (noPollCtx  * ctx,
 			/* release */
 			nopoll_mutex_unlock (ctx->ref_mutex);
 
+			nopoll_log (ctx, NOPOLL_LEVEL_INFO, "Unregistered connection id %d", conn->id);
 			/* acquire a reference to the conection */
 			nopoll_conn_unref (conn);
 			return;

--- a/src/nopoll_ctx.c
+++ b/src/nopoll_ctx.c
@@ -337,7 +337,6 @@ void           nopoll_ctx_unregister_conn (noPollCtx  * ctx,
 
 			/* acquire a reference to the conection */
 			nopoll_conn_unref (conn);
-            nopoll_log (ctx, NOPOLL_LEVEL_INFO, "Returning, unlock of mutex is not required ");
 			return;
 		} /* end if */
 		


### PR DESCRIPTION
The message "unlock of mutex is not required"  is not true, so we will replace it with a message telling the conn id.  So if we see these messages in a loop, we can tell if it's the same connection being multiply unregistered.
