### PR TITLE
Title: Memory leak fix

### DIFF
--- a/src/nopoll_conn.c
+++ b/src/nopoll_conn.c
@@ -2296,7 +2296,7 @@ void nopoll_conn_unref (noPollConn * conn)
 		nopoll_free (conn->handshake->expected_accept);
 		nopoll_free (conn->handshake->cookie);
 		nopoll_free (conn->handshake->redirectURL);
-               nopoll_free (conn->handshake);
+                nopoll_free (conn->handshake);
 	} /* end if */
 
 	/* release connection options if defined and reuse flag is not defined */

--- a/src/nopoll_conn.c
+++ b/src/nopoll_conn.c
@@ -2295,8 +2295,8 @@ void nopoll_conn_unref (noPollConn * conn)
 		nopoll_free (conn->handshake->websocket_accept);
 		nopoll_free (conn->handshake->expected_accept);
 		nopoll_free (conn->handshake->cookie);
-		nopoll_free (conn->handshake);
 		nopoll_free (conn->handshake->redirectURL);
+               nopoll_free (conn->handshake);
 	} /* end if */
 
 	/* release connection options if defined and reuse flag is not defined */


### PR DESCRIPTION
Reason for change : The order of unreferencing was wrong, leading to leak redirectURL struct member as the parent reference is freed first and then tried to free the child of freed parent pointer. This commit fixes the same